### PR TITLE
Update project to .NET 9

### DIFF
--- a/CollapsibleNavMenu.csproj
+++ b/CollapsibleNavMenu.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <RazorLangVersion>8.0</RazorLangVersion>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+  <TargetFramework>net9.0</TargetFramework>
+  <RazorLangVersion>9.0</RazorLangVersion>
+  <ImplicitUsings>enable</ImplicitUsings>
+  <Nullable>enable</Nullable>
+  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
     <!-- Packaging Metadata -->
     <PackageId>CollapsibleNavMenu</PackageId>
@@ -29,9 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="8.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />
-    <None Include="README.md" Pack="true" PackagePath="\"/>
+  <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.0" />
+  <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+  <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/ExampleApp/ExampleApp.csproj
+++ b/ExampleApp/ExampleApp.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
+  <TargetFramework>net9.0</TargetFramework>
+  <Nullable>enable</Nullable>
+  <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.14" />
+  <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
+  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CollapsibleNavMenu.csproj" />


### PR DESCRIPTION
## Summary
- upgrade CollapsibleNavMenu and ExampleApp to `net9.0`
- bump Blazor package references to 9.0.0
- disable automatic assembly info generation to avoid duplicate attributes
- fix broken README packaging path entry

## Testing
- `dotnet restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853365754888330b64025fa94ec295f