### PR TITLE
Convert example app to Blazor Server

### DIFF
--- a/ExampleApp/ExampleApp.csproj
+++ b/ExampleApp/ExampleApp.csproj
@@ -1,13 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
   <TargetFramework>net9.0</TargetFramework>
   <Nullable>enable</Nullable>
   <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <ItemGroup>
-  <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.0" />
-  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CollapsibleNavMenu.csproj" />
   </ItemGroup>

--- a/ExampleApp/Pages/_Host.cshtml
+++ b/ExampleApp/Pages/_Host.cshtml
@@ -1,15 +1,23 @@
+@page "/"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@{
+    Layout = null;
+}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
     <title>CollapsibleNavMenu Demo</title>
-    <base href="/" />
+    <base href="~/" />
     <link href="_content/CollapsibleNavMenu/CollapsibleMenuComponent.bundle.scoped.css" rel="stylesheet" />
     <link href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
-    <div id="app">Loading...</div>
+    <app>
+        <component type="typeof(App)" render-mode="ServerPrerendered" />
+    </app>
 
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_framework/blazor.server.js"></script>
 </body>
 </html>

--- a/ExampleApp/Program.cs
+++ b/ExampleApp/Program.cs
@@ -1,12 +1,14 @@
 using CollapsibleNavMenu.Services;
-using Microsoft.AspNetCore.Components.Web;
-using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
-var builder = WebAssemblyHostBuilder.CreateDefault(args);
-builder.RootComponents.Add<App>("#app");
-builder.RootComponents.Add<HeadOutlet>("head::after");
+var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
 builder.Services.AddScoped<INavMenuProvider, JsonNavMenuProvider>();
 
-await builder.Build().RunAsync();
+var app = builder.Build();
+
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ builder.Services.AddScoped<INavMenuProvider, JsonNavMenuProvider>();
 
 ## 🎮 Demo Application
 
-A sample Blazor WebAssembly project is included in the `ExampleApp` folder. This
-app references the library project and shows the `CollapsibleMenuComponent` in
+A sample Blazor Server project is included in the `ExampleApp` folder. This app
+references the library project and shows the `CollapsibleMenuComponent` in
 action. After opening the solution, set `ExampleApp` as the startup project and
 run the application to explore the navigation menu.
 


### PR DESCRIPTION
## Summary
- convert ExampleApp from a Blazor WebAssembly app to a Blazor Server app
- remove old WASM index.html and add `_Host.cshtml`
- update README demo section

## Testing
- `dotnet` command not found in container, so build could not be run

------
https://chatgpt.com/codex/tasks/task_e_68534afb45a483309c0a697820370b70